### PR TITLE
Add CHOP command to rxstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ Note: the key shouldn't be repeated for the executed command.
 **Reply:** Null if not equal or for non existing key when the `XX` flag is used.
 On success, the reply depends on the actual command executed.
 
+## `CHOP key count`
+
+Removes characters from a value of a String key.
+
+* If 'count' is positive, it removes from the right of the string;
+* if 'count' is negative, it removes from the left of the string.
+* If |count| is greater than the string length, the value is set as an empty string.
+* If 'count' is zero, then the value remains unchanged.
+* It is an error if the value is not a String.
+
+**Reply:** Integer, the length of the string after the chop operation.
+
 ## `PREPEND key value`
 
 > Time complexity: O(1). The amortized time complexity is O(1) assuming the prepended value is small and the already present value is of any size, since the dynamic string library used by Redis will double the free space available on every reallocation.

--- a/src/rxstrings.c
+++ b/src/rxstrings.c
@@ -163,7 +163,7 @@ int ChopCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   /* Key must be a string. */
   if (RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_STRING) {
     RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
-    return REDISMODULE_OK;
+    return REDISMODULE_ERR;
   }
 
   /* Calculate new length, protecting against overchop */
@@ -237,7 +237,7 @@ int PrependCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
   /* Otherwise key must be a string. */
   if (RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_STRING) {
     RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
-    return REDISMODULE_OK;
+    return REDISMODULE_ERR;
   }
 
   /* Prepend the string: 1) expand string, 2) shift oldVal via memmove, 3) prepend arg */


### PR DESCRIPTION
Note that tests for this module will fail until [this redis pull request](https://github.com/antirez/redis/pull/3718) is merged.

CHOP key count

Removes characters from a value to a String key.
If 'count' is positive or zero, it removes from the right of the string;
if 'count' is negative, it removes from the left of the string.
If |count| is greater than the string length, the value is set as an empty string.
It is an error if the value is not a String.
Integer Reply: the length of the string after the chop operation.